### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Trondheim Sykkelkjøkken
+# Trondheim sykkelkjøkken
 
-This is the website of Trondheim Sykkelkjøkken
+This is the website of Trondheim sykkelkjøkken
 
 This is a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte);
 

--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8" />
 	<meta name="description" content="" />
 	<link rel="icon" href="/favicon.png" />
-	<title>Trondheim Sykkelkjøkken</title>
+	<title>Trondheim sykkelkjøkken</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 	<script>


### PR DESCRIPTION
We'll use "Trondheim sykkelkjøkken", instead of
"Trondheim Sykkelkjøkken". Me and Eiliv discussed this at some point. It follows traditional Norwegian naming conventions, and Språkrådet's recommendations:
https://www.sprakradet.no/sprakhjelp/Skriverad/navn-pa-foretak/