### PR TITLE
Migrate to Decap CMS (formerly Netlify CMS)

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -2,18 +2,18 @@ backend:
   name: git-gateway
   branch: main
 collections:
-  - label: 'Pages'
-    name: 'pages'
+  - label: "Pages"
+    name: "pages"
     files:
-      - label: 'Tools page'
-        name: 'tools'
-        file: 'src/routes/tools/+page.md'
+      - label: "Tools page"
+        name: "tools"
+        file: "src/routes/tools/+page.md"
         fields:
           - name: body
             widget: markdown
-      - label: 'Resources page'
-        name: 'resources'
-        file: 'src/routes/resources/+page.md'
+      - label: "Resources page"
+        name: "resources"
+        file: "src/routes/resources/+page.md"
         fields:
           - name: body
             widget: markdown
@@ -28,8 +28,8 @@ collections:
       - name: publication_date
         label: Publication Date
         widget: datetime
-        date_format: 'DD.MM.YYYY' # e.g. 24.12.2021
-        time_format: 'HH:mm' # e.g. 21:07
+        date_format: "DD.MM.YYYY" # e.g. 24.12.2021
+        time_format: "HH:mm" # e.g. 21:07
       - name: body
         widget: markdown
   - name: events
@@ -43,8 +43,8 @@ collections:
       - name: publication_date
         label: Publication Date
         widget: datetime
-        date_format: 'DD.MM.YYYY' # e.g. 24.12.2021
-        time_format: 'HH:mm' # e.g. 21:07
+        date_format: "DD.MM.YYYY" # e.g. 24.12.2021
+        time_format: "HH:mm" # e.g. 21:07
       - name: body
         widget: markdown
       - name: facebook_link
@@ -52,8 +52,8 @@ collections:
       - name: image
         widget: image
 
-media_folder: 'static/uploads'
-public_folder: '/uploads'
+media_folder: "static/uploads"
+public_folder: "/uploads"
 
 site_url: https://sykkelkjokken.no
 display_url: https://sykkelkjokken.no

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,14 +1,16 @@
 <!doctype html>
 <html>
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Content Manager</title>
-		<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-	</head>
 
-	<body>
-		<!-- Include the script that builds the page and powers Netlify CMS -->
-		<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
-	</body>
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Content Manager</title>
+	<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+</head>
+
+<body>
+	<!-- Include the script that builds the page and powers Netlify CMS -->
+	<script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Netlify CMS was rebranded as Decap, and all further development is done there.