### PR TITLE
Update "what's the bike kitchen" paragraph

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,12 +9,7 @@
 	<section>
 		<h1>Trondheim Bike Kitchen</h1>
 		<p>
-			Trondheim Bike Kitchen is a non-profit community bicycle workshop. Here members get access to tools and
-			guidance in how to repair their own bikes. "Bike kitchen" is an established concept for
-			sharing knowledge and resources on bike repair and similar initiatives exist in countries all
-			over the world. Our goal is to be a community for sharing knowledge about repairing and
-			inspiration for cycling. We also wish to contribute to reduce resource consumption by giving
-			bikes a longer life through repairs and good maintenance.
+			Trondheim Bike Kitchen is a membership-based community bicycle workshop run by a group of volunteers. We help each other learn how to repair our own bicycles, and we provide access to a wide range of tools. Everyone is welcome to become a member or a volunteer, regardless of bicycle repair skill. Our goal is to make cycling available to all of Trondheim, to spread cycling knowledge and joy, and to encourage enivironmentally friendly transport.
 		</p>
 	</section>
 	<img srcset={img6} alt="" class="banner" />


### PR DESCRIPTION
I really like having the "what's the bike kitchen" right there on the landing page. I've been thinking of setting up some posters at the bike kitchen with the same short introduction text, to help newcomers understand who we are and what we do. I made some drafts, then realized we had this text on the website, and wrote a new draft that's also based on the website's text.

What do you think? I wanted to make it as to the point as I could without losing nuance.

After merging, I'll use the same text as the website for the info poster.