### PR TITLE
Set up justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,12 @@
+# Start a dev server and open the website in your browser
+open:
+    npm run dev -- --open ||:
+
+# Start a dev server and host the website locally, show QR for mobile
+host:
+    #!/bin/bash
+    npm run dev -- --host &
+    pid=$!
+    ip=$(hostname -I | awk '{print $1}')
+    qrcode --small "http://${ip}:5173"
+    wait $pid  # Wait for something like ctrl-c to kill the process


### PR DESCRIPTION
During recent hacking I tried setting up a little justfile to make it easier to remember / not have to refer to readme every time to run the dev server so I can check how my changes look. 

Dunno if you've used justfiles before but I find them pretty useful! Making a PR for this so you can see.

For instance in https://github.com/Trondheim-Sykkelkjokken/website/pull/26 I made a PR because I didn't realize how to test on mobile otherwise. But now it's easy to remember how, just type `just host` and that runs the dev server on the local network and prints a qr in the terminal for mobile scanning:

![image](https://github.com/user-attachments/assets/c77e9fb5-a3d6-4ffc-8b1a-25ac7eaa06c0)
