### PR TITLE
Update membership page

### DIFF
--- a/src/content/translations/en/membership.json
+++ b/src/content/translations/en/membership.json
@@ -1,5 +1,5 @@
 {
-    "heading": "Become a member!",
+    "heading": "Become a member",
     "terms_call_to_action": "Click to read the terms and conditions",
     "parties": "Parties",
     "parties_text": "The seller is Trondheim sykkelkjokken, Professor Brochs gate 2, 7030 Trondheim, kontakt@sykkelkjokken.no, organization number 923049274, and is hereinafter referred to as the organization. The member is the consumer who enters into membership and is hereinafter referred to as the member.",
@@ -25,7 +25,6 @@
     "acceptance_bullet_4": "Help others and share your knowledge.",
     "participation": "ALL PARTICIPATION IN ACTIVITIES AT THE BIKE KITCHEN IS AT YOUR OWN RISK.",
     "warning": "If the code of conduct is not respected, you will have to leave the premises and the Bike Kitchen's activities, and you risk losing your membership.",
-    "signup": "Sign up",
     "name_field": "Full name:",
     "email_field": "Email:",
     "membership_type": "Membership type:",

--- a/src/content/translations/nb/membership.json
+++ b/src/content/translations/nb/membership.json
@@ -1,5 +1,5 @@
 {
-    "heading": "Bli medlem!",
+    "heading": "Bli medlem",
     "terms_call_to_action": "Klikk for å lese vilkår og betingelser",
     "parties": "Parter",
     "parties_text": "Selgeren er Trondheim sykkelkjøkken, Professor Brochs gate 2, 7030 Trondheim, kontakt@sykkelkjokken.no, organisasjonsnummer 923049274, og omtales heretter som organisasjonen. Medlemmet er forbrukeren som inngår medlemskap og omtales heretter som medlemmet.",
@@ -25,7 +25,6 @@
     "acceptance_bullet_4": "Hjelp andre og del av kunnskapen din.",
     "participation": "ALL DELTAGELSE I AKTIVITETER PÅ ELLER I REGI AV SYKKELKJØKKENET SKJER PÅ EGET ANSVAR",
     "warning": "Dersom retningslinjene ikke blir fulgt, må du forlate lokalene og sykkelkjøkkenets aktiviteter, og du risikerer å miste medlemskapet ditt.",
-    "signup": "Registrer deg",
     "name_field": "Fullt navn:",
     "email_field": "E-postadresse:",
     "membership_type": "Type medlemskap:",

--- a/src/content/translations/nn/membership.json
+++ b/src/content/translations/nn/membership.json
@@ -1,5 +1,5 @@
 {
-    "heading": "Bli medlem!",
+    "heading": "Bli medlem",
     "terms_call_to_action": "Klikk for å lese vilkår",
     "parties": "Partar",
     "parties_text": "Seljaren er Trondheim sykkelkjøkken, Professor Brochs gate 2, 7030 Trondheim, kontakt@sykkelkjokken.no, organisasjonsnummer 923049274, og omtalast heretter som organisasjonen. Medlemmen er forbrukaren som inngår medlemskap og omtalast heretter som medlemmen.",
@@ -25,7 +25,6 @@
     "acceptance_bullet_4": "Hjelp andre og del av kunnskapen din.",
     "participation": "ALL DELTAKING I AKTIVITETAR PÅ ELLER I REGI AV SYKKELKJØKKENET SKJER PÅ EIGE ANSVAR",
     "warning": "Dersom retningslinjene ikkje blir fylgd, må du forlate lokala og sykkelkjøkkenet sine aktivitetar, og du risikerar å miste medlemskapet ditt.",
-    "signup": "Registrer deg",
     "name_field": "Fullt namn:",
     "email_field": "E-postadresse:",
     "membership_type": "Type medlemskap:",

--- a/src/routes/membership/+page.svelte
+++ b/src/routes/membership/+page.svelte
@@ -15,11 +15,8 @@
 </script>
 
 <h1>{@html $t('membership.heading')}</h1>
-<Terms />
 
 <form method="POST">
-	<h2>{@html $t('membership.signup')}</h2>
-
 	<label>
 		{@html $t('membership.name_field')}<br />
 		<input required name="name" type="text" style="width: 100%; max-width: 300px;" />
@@ -118,3 +115,6 @@
 		font-weight: 500;
 	}
 </style>
+
+<div style="margin-top: 1rem;"></div>
+<Terms />


### PR DESCRIPTION
I suggest moving the terms and conditions all the way down. That makes the "Become a member" header and "Sign up" sub header immediately follow each other, so I just removed the latter.

Before and after:

<p>
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/8be8e232-d2a3-4a01-8b8b-91b785a030f4" />
<img width="49%" alt="image" src="https://github.com/user-attachments/assets/50310559-bb6e-4ae8-81f4-298e9926e768" />
</p>
