### PR TITLE
Update old actions

### DIFF
--- a/.github/workflows/update-counter.yml
+++ b/.github/workflows/update-counter.yml
@@ -9,11 +9,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - run: sudo apt-get purge -y man-db  # Speeds up install step
       - run: sudo apt-get update
       - run: sudo apt-get install -y jq curl moreutils
       - run: src/lib/data/update-stats.sh
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           commit_message: 'Chore: Update fixed bikes counter'


### PR DESCRIPTION
I think this should fix the node.js 20 deprecation warning we get: https://github.com/Trondheim-Sykkelkjokken/website/actions/runs/25148707108

<img width="921" height="304" alt="image" src="https://github.com/user-attachments/assets/47b47099-2303-40c3-8046-2bd2a1bbdc8f" />

And it's slightly safer to pin hashes than to rely on tags. 

~I don't think I can actually test it before merging to the default branch.~ Tested and seems good: https://github.com/Trondheim-Sykkelkjokken/website/actions/runs/25148910588
